### PR TITLE
Add OSM-style answer-script checking mockup (static prototype)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
-- 👋 Hi, I’m @sarthak261287
-- 👀 I’m interested in ...
-- 🌱 I’m currently learning ...
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
+# OSM Checking Practice Mockup
 
-<!---
-sarthak261287/sarthak261287 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+This repository contains a static, front-end-only prototype for planning an online answer-script marking workflow inspired by OSM-style checking.
+
+> **Important:** This is a training/demo page only. It is not affiliated with CBSE, does not use official CBSE branding, and does not collect evaluator credentials or real student data.
+
+## What is included
+
+- A responsive dashboard-style web page for a sample scripts queue, scanned answer-sheet viewer, and marking panel.
+- Question-wise mark inputs with automatic total calculation.
+- Demo interactions for filtering scripts, selecting a script, and submitting a mock evaluation.
+- A visible build-plan section that breaks the product into dashboard, viewer, mark-entry, and review-flow features.
+
+## Run locally
+
+Open `index.html` directly in a browser, or serve the folder with any static server:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit `http://localhost:8000`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OSM Checking Practice Mockup</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="top-banner">
+    <div>
+      <p class="eyebrow">Training prototype • Not an official CBSE service</p>
+      <h1>OSM Answer-Script Checking Mockup</h1>
+      <p class="subtitle">
+        A safe, static practice interface inspired by online script marking workflows for planning,
+        reviewing, annotating, and submitting sample evaluations.
+      </p>
+    </div>
+    <button class="help-button" type="button" aria-label="Open help tips">Help</button>
+  </header>
+
+  <main class="workspace" aria-label="OSM checking mock workspace">
+    <aside class="panel script-list" aria-labelledby="scripts-heading">
+      <div class="panel-heading">
+        <h2 id="scripts-heading">Scripts Queue</h2>
+        <span class="badge">Demo</span>
+      </div>
+      <label class="search-label" for="script-search">Find script</label>
+      <input id="script-search" type="search" placeholder="Search by roll no. or status" />
+      <ul class="queue" id="script-queue">
+        <li class="active" data-status="checking">
+          <strong>Roll 248315</strong>
+          <span>Q1–Q5 pending • 12 pages</span>
+        </li>
+        <li data-status="reviewed">
+          <strong>Roll 248426</strong>
+          <span>Reviewed • 10 pages</span>
+        </li>
+        <li data-status="flagged">
+          <strong>Roll 248599</strong>
+          <span>Needs moderation • 14 pages</span>
+        </li>
+        <li data-status="checking">
+          <strong>Roll 248712</strong>
+          <span>Q6–Q10 pending • 11 pages</span>
+        </li>
+      </ul>
+    </aside>
+
+    <section class="panel viewer" aria-labelledby="viewer-heading">
+      <div class="panel-heading viewer-toolbar">
+        <div>
+          <h2 id="viewer-heading">Scanned Answer Script</h2>
+          <p>Sample page 03 of 12 • Subject: Mathematics</p>
+        </div>
+        <div class="toolbar-actions" aria-label="Viewer controls">
+          <button type="button">−</button>
+          <span>100%</span>
+          <button type="button">+</button>
+        </div>
+      </div>
+
+      <article class="answer-sheet" aria-label="Sample answer sheet preview">
+        <div class="sheet-meta">
+          <span>Question 3(b)</span>
+          <span>Maximum Marks: 5</span>
+        </div>
+        <div class="handwritten-lines">
+          <span></span><span class="short"></span><span></span><span></span><span class="medium"></span>
+        </div>
+        <div class="annotation correct">✓ Method identified</div>
+        <div class="annotation note">Check final unit</div>
+        <div class="stamp">Sample only</div>
+      </article>
+    </section>
+
+    <aside class="panel marking" aria-labelledby="marking-heading">
+      <div class="panel-heading">
+        <h2 id="marking-heading">Marking Panel</h2>
+        <span class="timer" id="timer">18:00</span>
+      </div>
+
+      <form id="marks-form">
+        <fieldset>
+          <legend>Question-wise Marks</legend>
+          <label>Q1 <input type="number" min="0" max="5" value="4" /></label>
+          <label>Q2 <input type="number" min="0" max="5" value="3" /></label>
+          <label>Q3 <input type="number" min="0" max="5" value="4" /></label>
+          <label>Q4 <input type="number" min="0" max="5" value="0" /></label>
+          <label>Q5 <input type="number" min="0" max="5" value="0" /></label>
+        </fieldset>
+
+        <label class="comment-label" for="remarks">Evaluator remarks</label>
+        <textarea id="remarks" rows="4" placeholder="Add a short moderation note..."></textarea>
+
+        <div class="summary-card">
+          <span>Total awarded</span>
+          <strong id="total-marks">11 / 25</strong>
+        </div>
+
+        <div class="action-grid">
+          <button class="secondary" type="button">Flag</button>
+          <button class="secondary" type="button">Save Draft</button>
+          <button class="primary" type="submit">Submit Evaluation</button>
+        </div>
+      </form>
+    </aside>
+  </main>
+
+  <section class="planning-section" aria-labelledby="plan-heading">
+    <div>
+      <p class="eyebrow">Build plan</p>
+      <h2 id="plan-heading">Suggested pages and features</h2>
+    </div>
+    <div class="plan-grid">
+      <article>
+        <h3>1. Dashboard</h3>
+        <p>Show assigned bundles, status counts, deadlines, and moderation alerts.</p>
+      </article>
+      <article>
+        <h3>2. Script Viewer</h3>
+        <p>Display sample scanned pages with zoom, navigation, and annotation tools.</p>
+      </article>
+      <article>
+        <h3>3. Mark Entry</h3>
+        <p>Capture question-wise marks, remarks, flags, and automatic totals.</p>
+      </article>
+      <article>
+        <h3>4. Review Flow</h3>
+        <p>Provide draft saving, final submission confirmation, and moderation history.</p>
+      </article>
+    </div>
+  </section>
+
+  <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,51 @@
+const markInputs = document.querySelectorAll('#marks-form input[type="number"]');
+const totalMarks = document.querySelector('#total-marks');
+const queueItems = document.querySelectorAll('#script-queue li');
+const searchInput = document.querySelector('#script-search');
+const toast = document.querySelector('#toast');
+const timer = document.querySelector('#timer');
+const form = document.querySelector('#marks-form');
+
+function updateTotal() {
+  const total = [...markInputs].reduce((sum, input) => sum + Number(input.value || 0), 0);
+  totalMarks.textContent = `${total} / 25`;
+}
+
+function showToast(message) {
+  toast.textContent = message;
+  toast.classList.add('show');
+  window.setTimeout(() => toast.classList.remove('show'), 2400);
+}
+
+markInputs.forEach((input) => input.addEventListener('input', updateTotal));
+
+queueItems.forEach((item) => {
+  item.addEventListener('click', () => {
+    queueItems.forEach((queueItem) => queueItem.classList.remove('active'));
+    item.classList.add('active');
+    showToast(`${item.querySelector('strong').textContent} opened in demo viewer`);
+  });
+});
+
+searchInput.addEventListener('input', (event) => {
+  const query = event.target.value.trim().toLowerCase();
+  queueItems.forEach((item) => {
+    const text = item.textContent.toLowerCase();
+    item.hidden = query && !text.includes(query) && !item.dataset.status.includes(query);
+  });
+});
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  showToast('Demo evaluation submitted. No real data was sent.');
+});
+
+let secondsLeft = 18 * 60;
+window.setInterval(() => {
+  secondsLeft = Math.max(0, secondsLeft - 1);
+  const minutes = String(Math.floor(secondsLeft / 60)).padStart(2, '0');
+  const seconds = String(secondsLeft % 60).padStart(2, '0');
+  timer.textContent = `${minutes}:${seconds}`;
+}, 1000);
+
+updateTotal();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,413 @@
+:root {
+  color-scheme: light;
+  --bg: #eef3fb;
+  --panel: #ffffff;
+  --ink: #1f2937;
+  --muted: #667085;
+  --line: #d7deea;
+  --primary: #214f9f;
+  --primary-dark: #15366e;
+  --accent: #f59e0b;
+  --success: #0f8a5f;
+  --danger: #c2410c;
+  --shadow: 0 18px 45px rgba(31, 41, 55, 0.12);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, #dbeafe 0, var(--bg) 34rem);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+.top-banner {
+  align-items: center;
+  background: linear-gradient(135deg, var(--primary), #4f46e5);
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2rem clamp(1rem, 4vw, 3rem);
+}
+
+.eyebrow {
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  margin: 0 0 0.45rem;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1;
+  margin-bottom: 0.75rem;
+}
+
+.subtitle {
+  color: #dbeafe;
+  max-width: 62rem;
+}
+
+.help-button,
+button {
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 0.75rem 1.1rem;
+}
+
+.help-button {
+  background: #fff;
+  color: var(--primary);
+}
+
+.workspace {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 280px minmax(360px, 1fr) 320px;
+  padding: 1rem clamp(1rem, 3vw, 2rem);
+}
+
+.panel,
+.planning-section {
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(215, 222, 234, 0.9);
+  border-radius: 1.35rem;
+  box-shadow: var(--shadow);
+}
+
+.panel {
+  min-height: 34rem;
+  padding: 1rem;
+}
+
+.panel-heading {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.panel-heading h2 {
+  font-size: 1.05rem;
+  margin-bottom: 0.2rem;
+}
+
+.panel-heading p {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin-bottom: 0;
+}
+
+.badge,
+.timer {
+  background: #eef2ff;
+  border-radius: 999px;
+  color: var(--primary);
+  font-size: 0.78rem;
+  font-weight: 800;
+  padding: 0.35rem 0.6rem;
+}
+
+.search-label,
+.comment-label {
+  color: var(--muted);
+  display: block;
+  font-size: 0.84rem;
+  font-weight: 800;
+  margin-bottom: 0.35rem;
+}
+
+input,
+textarea {
+  border: 1px solid var(--line);
+  border-radius: 0.8rem;
+  padding: 0.75rem;
+  width: 100%;
+}
+
+.queue {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+}
+
+.queue li {
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  cursor: pointer;
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.9rem;
+}
+
+.queue li.active,
+.queue li:hover {
+  background: #eff6ff;
+  border-color: var(--primary);
+}
+
+.queue span {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.viewer {
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.viewer-toolbar {
+  align-items: center;
+}
+
+.toolbar-actions {
+  align-items: center;
+  background: #f8fafc;
+  border-radius: 999px;
+  display: flex;
+  gap: 0.65rem;
+  padding: 0.35rem;
+}
+
+.toolbar-actions button {
+  background: #fff;
+  border: 1px solid var(--line);
+  height: 2rem;
+  padding: 0;
+  width: 2rem;
+}
+
+.answer-sheet {
+  align-self: stretch;
+  background: #fffdf7;
+  border: 1px solid #eadfca;
+  border-radius: 1rem;
+  min-height: 27rem;
+  overflow: hidden;
+  padding: 1.4rem;
+  position: relative;
+}
+
+.sheet-meta {
+  border-bottom: 2px solid #d7c8aa;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 0.8rem;
+}
+
+.handwritten-lines {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2.2rem;
+}
+
+.handwritten-lines span {
+  background: linear-gradient(90deg, #94a3b8, transparent 85%);
+  border-radius: 999px;
+  height: 0.72rem;
+  opacity: 0.85;
+}
+
+.handwritten-lines .short {
+  width: 55%;
+}
+
+.handwritten-lines .medium {
+  width: 72%;
+}
+
+.annotation {
+  border-radius: 0.7rem;
+  font-weight: 800;
+  padding: 0.55rem 0.75rem;
+  position: absolute;
+}
+
+.annotation.correct {
+  border: 2px solid var(--success);
+  color: var(--success);
+  right: 2rem;
+  top: 8rem;
+  transform: rotate(-4deg);
+}
+
+.annotation.note {
+  background: #fef3c7;
+  color: #92400e;
+  left: 3rem;
+  top: 15rem;
+}
+
+.stamp {
+  border: 3px solid rgba(194, 65, 12, 0.5);
+  border-radius: 0.6rem;
+  bottom: 2rem;
+  color: rgba(194, 65, 12, 0.7);
+  font-size: 1.5rem;
+  font-weight: 900;
+  padding: 0.5rem 1rem;
+  position: absolute;
+  right: 2rem;
+  text-transform: uppercase;
+  transform: rotate(-10deg);
+}
+
+fieldset {
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  margin: 0 0 1rem;
+  padding: 1rem;
+}
+
+legend {
+  color: var(--muted);
+  font-weight: 800;
+  padding: 0 0.35rem;
+}
+
+fieldset label {
+  align-items: center;
+  display: grid;
+  font-weight: 800;
+  gap: 0.75rem;
+  grid-template-columns: 3rem 1fr;
+}
+
+.summary-card {
+  align-items: center;
+  background: #f8fafc;
+  border-radius: 1rem;
+  display: flex;
+  justify-content: space-between;
+  margin: 1rem 0;
+  padding: 1rem;
+}
+
+.summary-card span {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.summary-card strong {
+  color: var(--primary);
+  font-size: 1.3rem;
+}
+
+.action-grid {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: 1fr 1fr;
+}
+
+.action-grid .primary {
+  grid-column: 1 / -1;
+}
+
+.primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+.secondary {
+  background: #eef2ff;
+  color: var(--primary-dark);
+}
+
+.planning-section {
+  margin: 0 clamp(1rem, 3vw, 2rem) 2rem;
+  padding: 1.5rem;
+}
+
+.planning-section .eyebrow {
+  color: var(--primary);
+}
+
+.plan-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.plan-grid article {
+  background: #f8fafc;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  padding: 1rem;
+}
+
+.toast {
+  background: var(--ink);
+  border-radius: 999px;
+  bottom: 1rem;
+  color: #fff;
+  left: 50%;
+  opacity: 0;
+  padding: 0.8rem 1rem;
+  position: fixed;
+  transform: translate(-50%, 1rem);
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+@media (max-width: 1100px) {
+  .workspace,
+  .plan-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .viewer {
+    grid-column: 1 / -1;
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .top-banner,
+  .workspace,
+  .plan-grid {
+    display: block;
+  }
+
+  .help-button {
+    margin-top: 1rem;
+  }
+
+  .panel,
+  .plan-grid article {
+    margin-bottom: 1rem;
+  }
+
+  .sheet-meta,
+  .panel-heading {
+    display: block;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a safe, front-end-only prototype that replicates the look-and-feel and basic workflow of OSM-style answer-script checking for planning and training purposes. 
- Make the scope and non-affiliation explicit with a visible disclaimer so the page can be used as a demo without collecting real student/evaluator data.

### Description
- Add `index.html` implementing a scripts queue, scanned answer-sheet viewer, marking panel, and a build-plan section for suggested pages and features. 
- Add `styles.css` with responsive visual styling for desktop, tablet and mobile layouts, plus UI elements like toast, stamps and annotations. 
- Add `script.js` providing lightweight interactions: automatic question-wise total calculation, queue selection, search filtering, countdown timer, and demo submit toast. 
- Update `README.md` with a demo disclaimer and instructions to run the prototype locally via a static server (`python3 -m http.server 8000`).

### Testing
- Fetched the served page with `curl -fsS http://127.0.0.1:8000/index.html` and succeeded. 
- Checked JavaScript syntax with `node --check script.js` and it passed. 
- Parsed `index.html` using Python's `html.parser` (HTMLParser) which completed successfully. 
- Captured a visual verification using Playwright (`npx --yes playwright@latest screenshot --viewport-size=1440,1000 http://127.0.0.1:8000/index.html /tmp/osm-checking-mockup.png`) and a screenshot file was created (`/tmp/osm-checking-mockup.png`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a095045a15883249b509fb263ada298)