### PR TITLE
Add static OSM checking mockup frontend and lightweight SQLite API scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+backend/osm_mock.db

--- a/README.md
+++ b/README.md
@@ -1,10 +1,41 @@
-- 👋 Hi, I’m @sarthak261287
-- 👀 I’m interested in ...
-- 🌱 I’m currently learning ...
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
+# OSM Checking Practice Mockup
 
-<!---
-sarthak261287/sarthak261287 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+This repository contains a static, front-end-only prototype for planning an online answer-script marking workflow inspired by OSM-style checking.
+
+> **Important:** This is a training/demo page only. It is not affiliated with CBSE, does not use official CBSE branding, and does not collect evaluator credentials or real student data.
+
+## What is included
+
+- A responsive dashboard-style web page for a sample scripts queue, scanned answer-sheet viewer, and marking panel.
+- Question-wise mark inputs with automatic total calculation.
+- Demo interactions for filtering scripts, selecting a script, and submitting a mock evaluation.
+- A visible build-plan section that breaks the product into dashboard, viewer, mark-entry, and review-flow features.
+
+## Run locally
+
+Open `index.html` directly in a browser, or serve the folder with any static server:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit `http://localhost:8000`.
+
+## Backend and database scaffold
+
+A lightweight Python/SQLite API scaffold is included for planning the system pipeline:
+
+```bash
+python3 backend/app.py
+```
+
+Useful demo endpoints:
+
+- `GET http://127.0.0.1:8080/health`
+- `GET http://127.0.0.1:8080/api/scripts`
+- `GET http://127.0.0.1:8080/api/scripts/1`
+- `PATCH http://127.0.0.1:8080/api/scripts/1/marks`
+- `POST http://127.0.0.1:8080/api/scripts/1/submit`
+
+See [`docs/backend-pipeline.md`](docs/backend-pipeline.md) for the recommended modules, database tables, API workflow, and production-readiness pipeline.
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Local API for the OSM checking practice mockup.
+
+This is deliberately small: SQLite for storage and Python's standard library for
+HTTP. It is useful for demos, database planning, and frontend wiring, but it is
+not a production exam-evaluation service.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parent
+DB_PATH = ROOT / "osm_mock.db"
+SCHEMA_PATH = ROOT / "schema.sql"
+
+API_HOST = "127.0.0.1"
+API_PORT = 8080
+DEMO_EVALUATOR_EMAIL = "evaluator@example.test"
+
+DEMO_BUNDLE = {
+    "subject": "Mathematics",
+    "exam_code": "DEMO-MATH-001",
+    "due_at": "2026-06-15T18:00:00Z",
+}
+
+DEMO_SCRIPTS = [
+    {"roll": "248315", "pages": 12, "status": "checking", "question": 3},
+    {"roll": "248426", "pages": 10, "status": "submitted", "question": 5},
+    {"roll": "248599", "pages": 14, "status": "flagged", "question": 2},
+    {"roll": "248712", "pages": 11, "status": "queued", "question": 6},
+]
+
+DEMO_QUESTIONS = [
+    ("Q1", 5, "Award method marks and final answer marks separately."),
+    ("Q2", 5, "Check formula selection, substitution, and simplification."),
+    ("Q3", 5, "Give partial credit for correct steps even if final unit is missing."),
+    ("Q4", 5, "Verify diagram labels before awarding construction marks."),
+    ("Q5", 5, "Award reasoning marks only when conclusion follows from working."),
+]
+
+
+def connect() -> sqlite3.Connection:
+    db = sqlite3.connect(DB_PATH)
+    db.row_factory = sqlite3.Row
+    db.execute("PRAGMA foreign_keys = ON")
+    return db
+
+
+def as_dict(row: sqlite3.Row) -> dict:
+    return dict(row)
+
+
+def initialize_database() -> None:
+    with connect() as db:
+        db.executescript(SCHEMA_PATH.read_text(encoding="utf-8"))
+        seed_database(db)
+
+
+def seed_database(db: sqlite3.Connection) -> None:
+    evaluator_id = upsert_demo_evaluator(db)
+    bundle_id = upsert_demo_bundle(db, evaluator_id)
+    seed_scripts(db, bundle_id)
+    seed_questions(db)
+    seed_script_pages(db)
+
+
+def upsert_demo_evaluator(db: sqlite3.Connection) -> int:
+    row = db.execute(
+        """
+        INSERT INTO users (name, email, role)
+        VALUES (?, ?, ?)
+        ON CONFLICT(email) DO UPDATE SET name = excluded.name
+        RETURNING id
+        """,
+        ("Demo Evaluator", DEMO_EVALUATOR_EMAIL, "evaluator"),
+    ).fetchone()
+    return int(row["id"])
+
+
+def upsert_demo_bundle(db: sqlite3.Connection, evaluator_id: int) -> int:
+    row = db.execute(
+        """
+        INSERT INTO script_bundles (subject, exam_code, status, assigned_to, due_at)
+        SELECT ?, ?, 'in_progress', ?, ?
+        WHERE NOT EXISTS (SELECT 1 FROM script_bundles WHERE exam_code = ?)
+        RETURNING id
+        """,
+        (
+            DEMO_BUNDLE["subject"],
+            DEMO_BUNDLE["exam_code"],
+            evaluator_id,
+            DEMO_BUNDLE["due_at"],
+            DEMO_BUNDLE["exam_code"],
+        ),
+    ).fetchone()
+
+    if row is None:
+        row = db.execute(
+            "SELECT id FROM script_bundles WHERE exam_code = ?",
+            (DEMO_BUNDLE["exam_code"],),
+        ).fetchone()
+
+    return int(row["id"])
+
+
+def seed_scripts(db: sqlite3.Connection, bundle_id: int) -> None:
+    records = [
+        (bundle_id, script["roll"], script["pages"], script["status"], script["question"])
+        for script in DEMO_SCRIPTS
+    ]
+    db.executemany(
+        """
+        INSERT OR IGNORE INTO answer_scripts
+          (bundle_id, masked_roll_no, page_count, status, current_question)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        records,
+    )
+
+
+def seed_questions(db: sqlite3.Connection) -> None:
+    records = [
+        (DEMO_BUNDLE["subject"], question_no, max_marks, rubric)
+        for question_no, max_marks, rubric in DEMO_QUESTIONS
+    ]
+    db.executemany(
+        """
+        INSERT INTO questions (subject, question_no, max_marks, rubric)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(subject, question_no) DO UPDATE SET
+          max_marks = excluded.max_marks,
+          rubric = excluded.rubric
+        """,
+        records,
+    )
+
+
+def seed_script_pages(db: sqlite3.Connection) -> None:
+    scripts = db.execute("SELECT id, page_count FROM answer_scripts").fetchall()
+
+    for script in scripts:
+        pages = [
+            (script["id"], page_number, f"/demo-pages/script-{script['id']}/page-{page_number:02}.png")
+            for page_number in range(1, script["page_count"] + 1)
+        ]
+        db.executemany(
+            """
+            INSERT OR IGNORE INTO script_pages (script_id, page_number, image_url)
+            VALUES (?, ?, ?)
+            """,
+            pages,
+        )
+
+
+def demo_evaluator_id(db: sqlite3.Connection) -> int:
+    row = db.execute(
+        "SELECT id FROM users WHERE email = ?",
+        (DEMO_EVALUATOR_EMAIL,),
+    ).fetchone()
+
+    if row is None:
+        raise RuntimeError("The demo evaluator has not been seeded")
+
+    return int(row["id"])
+
+
+def list_scripts() -> list[dict]:
+    with connect() as db:
+        rows = db.execute(
+            """
+            SELECT
+              answer_scripts.id,
+              answer_scripts.masked_roll_no,
+              answer_scripts.page_count,
+              answer_scripts.status,
+              answer_scripts.current_question,
+              answer_scripts.total_awarded,
+              script_bundles.subject,
+              script_bundles.exam_code
+            FROM answer_scripts
+            JOIN script_bundles ON script_bundles.id = answer_scripts.bundle_id
+            ORDER BY answer_scripts.id
+            """
+        ).fetchall()
+        return [as_dict(row) for row in rows]
+
+
+def get_script(script_id: int) -> dict | None:
+    with connect() as db:
+        script = find_script(db, script_id)
+        if script is None:
+            return None
+
+        evaluation = ensure_evaluation(db, script_id)
+        payload = as_dict(script)
+        payload["pages"] = list_pages(db, script_id)
+        payload["questions"] = list_questions(db, script["subject"])
+        payload["evaluation"] = as_dict(evaluation)
+        payload["marks"] = list_marks(db, evaluation["id"])
+        return payload
+
+
+def find_script(db: sqlite3.Connection, script_id: int) -> sqlite3.Row | None:
+    return db.execute(
+        """
+        SELECT
+          answer_scripts.*,
+          script_bundles.subject,
+          script_bundles.exam_code
+        FROM answer_scripts
+        JOIN script_bundles ON script_bundles.id = answer_scripts.bundle_id
+        WHERE answer_scripts.id = ?
+        """,
+        (script_id,),
+    ).fetchone()
+
+
+def list_pages(db: sqlite3.Connection, script_id: int) -> list[dict]:
+    rows = db.execute(
+        "SELECT page_number, image_url FROM script_pages WHERE script_id = ? ORDER BY page_number",
+        (script_id,),
+    ).fetchall()
+    return [as_dict(row) for row in rows]
+
+
+def list_questions(db: sqlite3.Connection, subject: str) -> list[dict]:
+    rows = db.execute(
+        "SELECT id, question_no, max_marks, rubric FROM questions WHERE subject = ? ORDER BY id",
+        (subject,),
+    ).fetchall()
+    return [as_dict(row) for row in rows]
+
+
+def list_marks(db: sqlite3.Connection, evaluation_id: int) -> list[dict]:
+    rows = db.execute(
+        """
+        SELECT questions.question_no, questions.max_marks, marks.awarded_marks, marks.comment
+        FROM marks
+        JOIN questions ON questions.id = marks.question_id
+        WHERE marks.evaluation_id = ?
+        ORDER BY questions.id
+        """,
+        (evaluation_id,),
+    ).fetchall()
+    return [as_dict(row) for row in rows]
+
+
+def ensure_evaluation(db: sqlite3.Connection, script_id: int) -> sqlite3.Row:
+    evaluator_id = demo_evaluator_id(db)
+    existing = db.execute(
+        "SELECT * FROM evaluations WHERE script_id = ? AND evaluator_id = ?",
+        (script_id, evaluator_id),
+    ).fetchone()
+
+    if existing is not None:
+        return existing
+
+    return db.execute(
+        """
+        INSERT INTO evaluations (script_id, evaluator_id, status)
+        VALUES (?, ?, 'draft')
+        RETURNING *
+        """,
+        (script_id, evaluator_id),
+    ).fetchone()
+
+
+def save_marks(script_id: int, marks: list[dict], remarks: str) -> dict | None:
+    with connect() as db:
+        script = find_script(db, script_id)
+        if script is None:
+            return None
+
+        evaluation = ensure_evaluation(db, script_id)
+        questions = questions_by_number(db, script["subject"])
+
+        for mark in marks:
+            save_single_mark(db, evaluation["id"], questions, mark)
+
+        total = total_awarded(db, evaluation["id"])
+        db.execute(
+            """
+            UPDATE evaluations
+            SET remarks = ?, status = 'draft', updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (remarks, evaluation["id"]),
+        )
+        db.execute(
+            """
+            UPDATE answer_scripts
+            SET total_awarded = ?, status = 'draft_saved', updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (total, script_id),
+        )
+        write_audit_event(
+            db,
+            script_id,
+            "marks_saved",
+            {"total_awarded": total, "questions_saved": len(marks)},
+        )
+        db.commit()
+
+    return get_script(script_id)
+
+
+def questions_by_number(db: sqlite3.Connection, subject: str) -> dict[str, sqlite3.Row]:
+    rows = db.execute(
+        "SELECT id, question_no, max_marks FROM questions WHERE subject = ? ORDER BY id",
+        (subject,),
+    ).fetchall()
+    return {row["question_no"].upper(): row for row in rows}
+
+
+def save_single_mark(
+    db: sqlite3.Connection,
+    evaluation_id: int,
+    questions: dict[str, sqlite3.Row],
+    mark: dict,
+) -> None:
+    question_no = str(mark.get("question_no", "")).strip().upper()
+    question = questions.get(question_no)
+
+    if question is None:
+        raise ValueError(f"Unknown question: {question_no or 'blank'}")
+
+    awarded = float(mark.get("awarded_marks", 0))
+    if awarded < 0 or awarded > question["max_marks"]:
+        raise ValueError(f"Marks for {question_no} must be between 0 and {question['max_marks']}")
+
+    db.execute(
+        """
+        INSERT INTO marks (evaluation_id, question_id, awarded_marks, comment, updated_at)
+        VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+        ON CONFLICT(evaluation_id, question_id) DO UPDATE SET
+          awarded_marks = excluded.awarded_marks,
+          comment = excluded.comment,
+          updated_at = CURRENT_TIMESTAMP
+        """,
+        (evaluation_id, question["id"], awarded, str(mark.get("comment", ""))),
+    )
+
+
+def total_awarded(db: sqlite3.Connection, evaluation_id: int) -> float:
+    row = db.execute(
+        "SELECT COALESCE(SUM(awarded_marks), 0) AS total FROM marks WHERE evaluation_id = ?",
+        (evaluation_id,),
+    ).fetchone()
+    return float(row["total"])
+
+
+def submit_script(script_id: int) -> dict | None:
+    with connect() as db:
+        script = find_script(db, script_id)
+        if script is None:
+            return None
+
+        evaluation = ensure_evaluation(db, script_id)
+        db.execute(
+            """
+            UPDATE evaluations
+            SET status = 'submitted', submitted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (evaluation["id"],),
+        )
+        db.execute(
+            """
+            UPDATE answer_scripts
+            SET status = 'submitted', updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (script_id,),
+        )
+        write_audit_event(db, script_id, "submitted")
+        db.commit()
+
+    return get_script(script_id)
+
+
+def write_audit_event(
+    db: sqlite3.Connection,
+    script_id: int,
+    action: str,
+    details: dict | None = None,
+) -> None:
+    db.execute(
+        """
+        INSERT INTO audit_events (actor_id, entity_type, entity_id, action, details)
+        VALUES (?, 'answer_script', ?, ?, ?)
+        """,
+        (demo_evaluator_id(db), script_id, action, json.dumps(details or {})),
+    )
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "OSMMockAPI/0.2"
+
+    def do_GET(self) -> None:
+        path = clean_path(self.path)
+
+        if path == ["health"]:
+            self.send_json({"status": "ok"})
+            return
+
+        if path == ["api", "scripts"]:
+            self.send_json({"scripts": list_scripts()})
+            return
+
+        if len(path) == 3 and path[:2] == ["api", "scripts"]:
+            self.send_script(path[2])
+            return
+
+        self.send_error_json(HTTPStatus.NOT_FOUND, "Route not found")
+
+    def do_PATCH(self) -> None:
+        path = clean_path(self.path)
+
+        is_marks_route = len(path) == 4 and path[:2] == ["api", "scripts"] and path[3] == "marks"
+        if is_marks_route:
+            script_id = parse_int(path[2])
+            if script_id is None:
+                self.send_error_json(HTTPStatus.NOT_FOUND, "Script not found")
+                return
+
+            try:
+                body = self.read_json_body()
+                script = save_marks(
+                    script_id,
+                    body.get("marks", []),
+                    body.get("remarks", ""),
+                )
+            except (json.JSONDecodeError, ValueError) as error:
+                self.send_error_json(HTTPStatus.BAD_REQUEST, str(error))
+                return
+
+            if script is None:
+                self.send_error_json(HTTPStatus.NOT_FOUND, "Script not found")
+                return
+
+            self.send_json(script)
+            return
+
+        self.send_error_json(HTTPStatus.NOT_FOUND, "Route not found")
+
+    def do_POST(self) -> None:
+        path = clean_path(self.path)
+
+        is_submit_route = len(path) == 4 and path[:2] == ["api", "scripts"] and path[3] == "submit"
+        if is_submit_route:
+            script_id = parse_int(path[2])
+            if script_id is None:
+                self.send_error_json(HTTPStatus.NOT_FOUND, "Script not found")
+                return
+
+            script = submit_script(script_id)
+            if script is None:
+                self.send_error_json(HTTPStatus.NOT_FOUND, "Script not found")
+                return
+
+            self.send_json(script)
+            return
+
+        self.send_error_json(HTTPStatus.NOT_FOUND, "Route not found")
+
+    def do_OPTIONS(self) -> None:
+        self.send_response(HTTPStatus.NO_CONTENT)
+        self.send_cors_headers()
+        self.end_headers()
+
+    def send_script(self, script_id_value: str) -> None:
+        script_id = parse_int(script_id_value)
+        if script_id is None:
+            self.send_error_json(HTTPStatus.NOT_FOUND, "Script not found")
+            return
+
+        script = get_script(script_id)
+        if script is None:
+            self.send_error_json(HTTPStatus.NOT_FOUND, "Script not found")
+            return
+
+        self.send_json(script)
+
+    def read_json_body(self) -> dict:
+        length = int(self.headers.get("Content-Length", "0"))
+        if length == 0:
+            return {}
+
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def send_json(self, payload: dict, status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = json.dumps(payload, indent=2).encode("utf-8")
+        self.send_response(status)
+        self.send_cors_headers()
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def send_error_json(self, status: HTTPStatus, message: str) -> None:
+        self.send_json({"error": message}, status)
+
+    def send_cors_headers(self) -> None:
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, PATCH, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+
+
+def clean_path(raw_path: str) -> list[str]:
+    return [part for part in urlparse(raw_path).path.split("/") if part]
+
+
+def parse_int(value: str) -> int | None:
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def main() -> None:
+    initialize_database()
+    address = (API_HOST, API_PORT)
+    print(f"OSM mock API running at http://{API_HOST}:{API_PORT}")
+    ThreadingHTTPServer(address, Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,96 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL UNIQUE,
+  role TEXT NOT NULL CHECK (role IN ('admin', 'evaluator', 'moderator')),
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS script_bundles (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  subject TEXT NOT NULL,
+  exam_code TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'assigned' CHECK (status IN ('assigned', 'in_progress', 'submitted', 'moderation', 'closed')),
+  assigned_to INTEGER REFERENCES users(id),
+  due_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS answer_scripts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  bundle_id INTEGER NOT NULL REFERENCES script_bundles(id) ON DELETE CASCADE,
+  masked_roll_no TEXT NOT NULL UNIQUE,
+  page_count INTEGER NOT NULL CHECK (page_count > 0),
+  status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'checking', 'draft_saved', 'submitted', 'flagged', 'moderated')),
+  current_question INTEGER NOT NULL DEFAULT 1,
+  total_awarded REAL NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS script_pages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  script_id INTEGER NOT NULL REFERENCES answer_scripts(id) ON DELETE CASCADE,
+  page_number INTEGER NOT NULL,
+  image_url TEXT NOT NULL,
+  UNIQUE (script_id, page_number)
+);
+
+CREATE TABLE IF NOT EXISTS questions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  subject TEXT NOT NULL,
+  question_no TEXT NOT NULL,
+  max_marks REAL NOT NULL CHECK (max_marks >= 0),
+  rubric TEXT NOT NULL,
+  UNIQUE (subject, question_no)
+);
+
+CREATE TABLE IF NOT EXISTS evaluations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  script_id INTEGER NOT NULL REFERENCES answer_scripts(id) ON DELETE CASCADE,
+  evaluator_id INTEGER NOT NULL REFERENCES users(id),
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'submitted', 'returned', 'approved')),
+  remarks TEXT NOT NULL DEFAULT '',
+  submitted_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (script_id, evaluator_id)
+);
+
+CREATE TABLE IF NOT EXISTS marks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  evaluation_id INTEGER NOT NULL REFERENCES evaluations(id) ON DELETE CASCADE,
+  question_id INTEGER NOT NULL REFERENCES questions(id),
+  awarded_marks REAL NOT NULL CHECK (awarded_marks >= 0),
+  comment TEXT NOT NULL DEFAULT '',
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (evaluation_id, question_id)
+);
+
+CREATE TABLE IF NOT EXISTS annotations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  evaluation_id INTEGER NOT NULL REFERENCES evaluations(id) ON DELETE CASCADE,
+  page_id INTEGER NOT NULL REFERENCES script_pages(id),
+  annotation_type TEXT NOT NULL CHECK (annotation_type IN ('tick', 'cross', 'note', 'highlight')),
+  x REAL NOT NULL CHECK (x >= 0),
+  y REAL NOT NULL CHECK (y >= 0),
+  note TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS audit_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  actor_id INTEGER REFERENCES users(id),
+  entity_type TEXT NOT NULL,
+  entity_id INTEGER NOT NULL,
+  action TEXT NOT NULL,
+  details TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_answer_scripts_status ON answer_scripts(status);
+CREATE INDEX IF NOT EXISTS idx_evaluations_script ON evaluations(script_id);
+CREATE INDEX IF NOT EXISTS idx_marks_evaluation ON marks(evaluation_id);
+CREATE INDEX IF NOT EXISTS idx_audit_entity ON audit_events(entity_type, entity_id);

--- a/docs/backend-pipeline.md
+++ b/docs/backend-pipeline.md
@@ -1,0 +1,84 @@
+# Backend and Database Pipeline Plan
+
+This plan turns the static OSM checking mockup into a real, auditable evaluation system. Keep the current project as a training/demo application unless you receive explicit legal, security, and board-level approval for handling real examination data.
+
+## 1. Recommended system modules
+
+1. **Authentication and roles**
+   - Use separate roles for `admin`, `evaluator`, and `moderator`.
+   - Enforce multi-factor authentication and session expiry for evaluator accounts.
+   - Never store plain-text passwords; use a managed identity provider where possible.
+2. **Bundle assignment**
+   - Import anonymized answer-script metadata into bundles.
+   - Assign bundles to evaluators with due dates, status tracking, and conflict-of-interest checks.
+3. **Script viewer service**
+   - Store scanned pages in private object storage.
+   - Serve pages through short-lived signed URLs, not public file paths.
+4. **Evaluation service**
+   - Save draft marks question-by-question.
+   - Validate each mark against the question maximum before saving.
+   - Require final confirmation before submission.
+5. **Moderation and audit**
+   - Route flagged scripts and random samples to moderators.
+   - Record every save, submit, approve, return, and mark change in an append-only audit log.
+
+## 2. Data flow pipeline
+
+```text
+Scan upload -> OCR/page validation -> anonymization -> bundle creation
+  -> evaluator assignment -> draft marking -> validation -> final submit
+  -> moderation sampling/flag review -> locked results export -> archive
+```
+
+## 3. Database tables
+
+The prototype schema in `backend/schema.sql` includes these core tables:
+
+- `users`: evaluator, moderator, and admin identities.
+- `script_bundles`: subject/exam bundles assigned to evaluators.
+- `answer_scripts`: anonymized script records and workflow status.
+- `script_pages`: page ordering and private image references.
+- `questions`: question maxima and rubric text.
+- `evaluations`: one evaluator's draft/submitted evaluation for a script.
+- `marks`: question-wise marks linked to an evaluation.
+- `annotations`: page-level notes, ticks, highlights, or review comments.
+- `audit_events`: immutable trail for compliance and moderation.
+
+For production, add encryption-at-rest, backups, row-level authorization, and a strict data-retention policy.
+
+## 4. API endpoints in this scaffold
+
+The local standard-library API in `backend/app.py` provides a small starting point:
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `GET` | `/health` | Check that the API is running. |
+| `GET` | `/api/scripts` | List assigned demo scripts. |
+| `GET` | `/api/scripts/{id}` | Load script pages, questions, evaluation, and marks. |
+| `PATCH` | `/api/scripts/{id}/marks` | Save draft question-wise marks and remarks. |
+| `POST` | `/api/scripts/{id}/submit` | Submit the demo evaluation. |
+
+## 5. Development pipeline
+
+1. **Local development**
+   - Run the frontend with `python3 -m http.server 8000`.
+   - Run the API with `python3 backend/app.py`.
+   - Use SQLite for local demos only.
+2. **Testing**
+   - Unit test mark validation, status transitions, and audit-event creation.
+   - Integration test API endpoints with a temporary database.
+   - Add accessibility and visual regression checks for the frontend.
+3. **Staging**
+   - Replace local SQLite with PostgreSQL.
+   - Replace demo page paths with private object storage signed URLs.
+   - Enable realistic anonymized test data only.
+4. **Production readiness**
+   - Add identity provider integration, MFA, RBAC, audit exports, backup drills, monitoring, and incident response.
+   - Complete privacy review and threat modeling before any real exam data enters the system.
+
+## 6. Next implementation steps
+
+- Connect `script.js` to `GET /api/scripts` and `PATCH /api/scripts/{id}/marks`.
+- Add login/session middleware before exposing any non-demo data.
+- Add automated tests around `backend/app.py` using a temporary SQLite database.
+- Move script images to protected storage and store only signed URL references in API responses.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OSM Checking Practice Mockup</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="top-banner">
+    <div>
+      <p class="eyebrow">Training prototype • Not an official CBSE service</p>
+      <h1>OSM Answer-Script Checking Mockup</h1>
+      <p class="subtitle">
+        A safe, static practice interface inspired by online script marking workflows for planning,
+        reviewing, annotating, and submitting sample evaluations.
+      </p>
+    </div>
+    <button class="help-button" type="button" aria-label="Open help tips">Help</button>
+  </header>
+
+  <main class="workspace" aria-label="OSM checking mock workspace">
+    <aside class="panel script-list" aria-labelledby="scripts-heading">
+      <div class="panel-heading">
+        <h2 id="scripts-heading">Scripts Queue</h2>
+        <span class="badge">Demo</span>
+      </div>
+      <label class="search-label" for="script-search">Find script</label>
+      <input id="script-search" type="search" placeholder="Search by roll no. or status" />
+      <ul class="queue" id="script-queue">
+        <li class="active" data-status="checking">
+          <strong>Roll 248315</strong>
+          <span>Q1–Q5 pending • 12 pages</span>
+        </li>
+        <li data-status="reviewed">
+          <strong>Roll 248426</strong>
+          <span>Reviewed • 10 pages</span>
+        </li>
+        <li data-status="flagged">
+          <strong>Roll 248599</strong>
+          <span>Needs moderation • 14 pages</span>
+        </li>
+        <li data-status="checking">
+          <strong>Roll 248712</strong>
+          <span>Q6–Q10 pending • 11 pages</span>
+        </li>
+      </ul>
+    </aside>
+
+    <section class="panel viewer" aria-labelledby="viewer-heading">
+      <div class="panel-heading viewer-toolbar">
+        <div>
+          <h2 id="viewer-heading">Scanned Answer Script</h2>
+          <p>Sample page 03 of 12 • Subject: Mathematics</p>
+        </div>
+        <div class="toolbar-actions" aria-label="Viewer controls">
+          <button type="button">−</button>
+          <span>100%</span>
+          <button type="button">+</button>
+        </div>
+      </div>
+
+      <article class="answer-sheet" aria-label="Sample answer sheet preview">
+        <div class="sheet-meta">
+          <span>Question 3(b)</span>
+          <span>Maximum Marks: 5</span>
+        </div>
+        <div class="handwritten-lines">
+          <span></span><span class="short"></span><span></span><span></span><span class="medium"></span>
+        </div>
+        <div class="annotation correct">✓ Method identified</div>
+        <div class="annotation note">Check final unit</div>
+        <div class="stamp">Sample only</div>
+      </article>
+    </section>
+
+    <aside class="panel marking" aria-labelledby="marking-heading">
+      <div class="panel-heading">
+        <h2 id="marking-heading">Marking Panel</h2>
+        <span class="timer" id="timer">18:00</span>
+      </div>
+
+      <form id="marks-form">
+        <fieldset>
+          <legend>Question-wise Marks</legend>
+          <label>Q1 <input type="number" min="0" max="5" value="4" /></label>
+          <label>Q2 <input type="number" min="0" max="5" value="3" /></label>
+          <label>Q3 <input type="number" min="0" max="5" value="4" /></label>
+          <label>Q4 <input type="number" min="0" max="5" value="0" /></label>
+          <label>Q5 <input type="number" min="0" max="5" value="0" /></label>
+        </fieldset>
+
+        <label class="comment-label" for="remarks">Evaluator remarks</label>
+        <textarea id="remarks" rows="4" placeholder="Add a short moderation note..."></textarea>
+
+        <div class="summary-card">
+          <span>Total awarded</span>
+          <strong id="total-marks">11 / 25</strong>
+        </div>
+
+        <div class="action-grid">
+          <button class="secondary" type="button">Flag</button>
+          <button class="secondary" type="button">Save Draft</button>
+          <button class="primary" type="submit">Submit Evaluation</button>
+        </div>
+      </form>
+    </aside>
+  </main>
+
+  <section class="planning-section" aria-labelledby="plan-heading">
+    <div>
+      <p class="eyebrow">Build plan</p>
+      <h2 id="plan-heading">Suggested pages and features</h2>
+    </div>
+    <div class="plan-grid">
+      <article>
+        <h3>1. Dashboard</h3>
+        <p>Show assigned bundles, status counts, deadlines, and moderation alerts.</p>
+      </article>
+      <article>
+        <h3>2. Script Viewer</h3>
+        <p>Display sample scanned pages with zoom, navigation, and annotation tools.</p>
+      </article>
+      <article>
+        <h3>3. Mark Entry</h3>
+        <p>Capture question-wise marks, remarks, flags, and automatic totals.</p>
+      </article>
+      <article>
+        <h3>4. Review Flow</h3>
+        <p>Provide draft saving, final submission confirmation, and moderation history.</p>
+      </article>
+    </div>
+  </section>
+
+  <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,79 @@
+const $ = (selector) => document.querySelector(selector);
+const $$ = (selector) => Array.from(document.querySelectorAll(selector));
+
+const marksForm = $('#marks-form');
+const markInputs = $$('#marks-form input[type="number"]');
+const queueItems = $$('#script-queue li');
+const searchInput = $('#script-search');
+const timer = $('#timer');
+const toast = $('#toast');
+const totalMarks = $('#total-marks');
+
+const TOAST_DURATION_MS = 2400;
+const TIMER_DURATION_SECONDS = 18 * 60;
+
+let toastTimeout;
+let secondsLeft = TIMER_DURATION_SECONDS;
+
+function maxMarks() {
+  return markInputs.reduce((total, input) => total + Number(input.max || 0), 0);
+}
+
+function awardedMarks() {
+  return markInputs.reduce((total, input) => total + Number(input.value || 0), 0);
+}
+
+function updateTotal() {
+  totalMarks.textContent = `${awardedMarks()} / ${maxMarks()}`;
+}
+
+function showToast(message) {
+  window.clearTimeout(toastTimeout);
+  toast.textContent = message;
+  toast.classList.add('show');
+
+  toastTimeout = window.setTimeout(() => {
+    toast.classList.remove('show');
+  }, TOAST_DURATION_MS);
+}
+
+function selectScript(item) {
+  queueItems.forEach((queueItem) => queueItem.classList.remove('active'));
+  item.classList.add('active');
+
+  const rollNumber = item.querySelector('strong').textContent;
+  showToast(`${rollNumber} opened in the demo viewer`);
+}
+
+function filterScripts() {
+  const query = searchInput.value.trim().toLowerCase();
+
+  queueItems.forEach((item) => {
+    const label = item.textContent.toLowerCase();
+    const status = item.dataset.status.toLowerCase();
+    item.hidden = Boolean(query && !label.includes(query) && !status.includes(query));
+  });
+}
+
+function formatTimer(totalSeconds) {
+  const minutes = String(Math.floor(totalSeconds / 60)).padStart(2, '0');
+  const seconds = String(totalSeconds % 60).padStart(2, '0');
+  return `${minutes}:${seconds}`;
+}
+
+function tickTimer() {
+  secondsLeft = Math.max(0, secondsLeft - 1);
+  timer.textContent = formatTimer(secondsLeft);
+}
+
+markInputs.forEach((input) => input.addEventListener('input', updateTotal));
+queueItems.forEach((item) => item.addEventListener('click', () => selectScript(item)));
+searchInput.addEventListener('input', filterScripts);
+
+marksForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  showToast('Demo evaluation submitted. No real data was sent.');
+});
+
+updateTotal();
+window.setInterval(tickTimer, 1000);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,413 @@
+:root {
+  color-scheme: light;
+  --bg: #eef3fb;
+  --panel: #ffffff;
+  --ink: #1f2937;
+  --muted: #667085;
+  --line: #d7deea;
+  --primary: #214f9f;
+  --primary-dark: #15366e;
+  --accent: #f59e0b;
+  --success: #0f8a5f;
+  --danger: #c2410c;
+  --shadow: 0 18px 45px rgba(31, 41, 55, 0.12);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, #dbeafe 0, var(--bg) 34rem);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+.top-banner {
+  align-items: center;
+  background: linear-gradient(135deg, var(--primary), #4f46e5);
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2rem clamp(1rem, 4vw, 3rem);
+}
+
+.eyebrow {
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  margin: 0 0 0.45rem;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1;
+  margin-bottom: 0.75rem;
+}
+
+.subtitle {
+  color: #dbeafe;
+  max-width: 62rem;
+}
+
+.help-button,
+button {
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 0.75rem 1.1rem;
+}
+
+.help-button {
+  background: #fff;
+  color: var(--primary);
+}
+
+.workspace {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 280px minmax(360px, 1fr) 320px;
+  padding: 1rem clamp(1rem, 3vw, 2rem);
+}
+
+.panel,
+.planning-section {
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(215, 222, 234, 0.9);
+  border-radius: 1.35rem;
+  box-shadow: var(--shadow);
+}
+
+.panel {
+  min-height: 34rem;
+  padding: 1rem;
+}
+
+.panel-heading {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.panel-heading h2 {
+  font-size: 1.05rem;
+  margin-bottom: 0.2rem;
+}
+
+.panel-heading p {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin-bottom: 0;
+}
+
+.badge,
+.timer {
+  background: #eef2ff;
+  border-radius: 999px;
+  color: var(--primary);
+  font-size: 0.78rem;
+  font-weight: 800;
+  padding: 0.35rem 0.6rem;
+}
+
+.search-label,
+.comment-label {
+  color: var(--muted);
+  display: block;
+  font-size: 0.84rem;
+  font-weight: 800;
+  margin-bottom: 0.35rem;
+}
+
+input,
+textarea {
+  border: 1px solid var(--line);
+  border-radius: 0.8rem;
+  padding: 0.75rem;
+  width: 100%;
+}
+
+.queue {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+}
+
+.queue li {
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  cursor: pointer;
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.9rem;
+}
+
+.queue li.active,
+.queue li:hover {
+  background: #eff6ff;
+  border-color: var(--primary);
+}
+
+.queue span {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.viewer {
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.viewer-toolbar {
+  align-items: center;
+}
+
+.toolbar-actions {
+  align-items: center;
+  background: #f8fafc;
+  border-radius: 999px;
+  display: flex;
+  gap: 0.65rem;
+  padding: 0.35rem;
+}
+
+.toolbar-actions button {
+  background: #fff;
+  border: 1px solid var(--line);
+  height: 2rem;
+  padding: 0;
+  width: 2rem;
+}
+
+.answer-sheet {
+  align-self: stretch;
+  background: #fffdf7;
+  border: 1px solid #eadfca;
+  border-radius: 1rem;
+  min-height: 27rem;
+  overflow: hidden;
+  padding: 1.4rem;
+  position: relative;
+}
+
+.sheet-meta {
+  border-bottom: 2px solid #d7c8aa;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 0.8rem;
+}
+
+.handwritten-lines {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2.2rem;
+}
+
+.handwritten-lines span {
+  background: linear-gradient(90deg, #94a3b8, transparent 85%);
+  border-radius: 999px;
+  height: 0.72rem;
+  opacity: 0.85;
+}
+
+.handwritten-lines .short {
+  width: 55%;
+}
+
+.handwritten-lines .medium {
+  width: 72%;
+}
+
+.annotation {
+  border-radius: 0.7rem;
+  font-weight: 800;
+  padding: 0.55rem 0.75rem;
+  position: absolute;
+}
+
+.annotation.correct {
+  border: 2px solid var(--success);
+  color: var(--success);
+  right: 2rem;
+  top: 8rem;
+  transform: rotate(-4deg);
+}
+
+.annotation.note {
+  background: #fef3c7;
+  color: #92400e;
+  left: 3rem;
+  top: 15rem;
+}
+
+.stamp {
+  border: 3px solid rgba(194, 65, 12, 0.5);
+  border-radius: 0.6rem;
+  bottom: 2rem;
+  color: rgba(194, 65, 12, 0.7);
+  font-size: 1.5rem;
+  font-weight: 900;
+  padding: 0.5rem 1rem;
+  position: absolute;
+  right: 2rem;
+  text-transform: uppercase;
+  transform: rotate(-10deg);
+}
+
+fieldset {
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  margin: 0 0 1rem;
+  padding: 1rem;
+}
+
+legend {
+  color: var(--muted);
+  font-weight: 800;
+  padding: 0 0.35rem;
+}
+
+fieldset label {
+  align-items: center;
+  display: grid;
+  font-weight: 800;
+  gap: 0.75rem;
+  grid-template-columns: 3rem 1fr;
+}
+
+.summary-card {
+  align-items: center;
+  background: #f8fafc;
+  border-radius: 1rem;
+  display: flex;
+  justify-content: space-between;
+  margin: 1rem 0;
+  padding: 1rem;
+}
+
+.summary-card span {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.summary-card strong {
+  color: var(--primary);
+  font-size: 1.3rem;
+}
+
+.action-grid {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: 1fr 1fr;
+}
+
+.action-grid .primary {
+  grid-column: 1 / -1;
+}
+
+.primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+.secondary {
+  background: #eef2ff;
+  color: var(--primary-dark);
+}
+
+.planning-section {
+  margin: 0 clamp(1rem, 3vw, 2rem) 2rem;
+  padding: 1.5rem;
+}
+
+.planning-section .eyebrow {
+  color: var(--primary);
+}
+
+.plan-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.plan-grid article {
+  background: #f8fafc;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  padding: 1rem;
+}
+
+.toast {
+  background: var(--ink);
+  border-radius: 999px;
+  bottom: 1rem;
+  color: #fff;
+  left: 50%;
+  opacity: 0;
+  padding: 0.8rem 1rem;
+  position: fixed;
+  transform: translate(-50%, 1rem);
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+@media (max-width: 1100px) {
+  .workspace,
+  .plan-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .viewer {
+    grid-column: 1 / -1;
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .top-banner,
+  .workspace,
+  .plan-grid {
+    display: block;
+  }
+
+  .help-button {
+    margin-top: 1rem;
+  }
+
+  .panel,
+  .plan-grid article {
+    margin-bottom: 1rem;
+  }
+
+  .sheet-meta,
+  .panel-heading {
+    display: block;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a safe, local demo of an OSM-style answer-script checking workflow for planning and frontend/back-end integration without real exam data.
- Capture a minimal backend schema and API contract to guide production design and testing.

### Description

- Add a static frontend prototype including `index.html`, `styles.css`, and `script.js` to demonstrate a scripts queue, viewer, mark entry, and draft/submit interactions.
- Add a lightweight Python HTTP API scaffold in `backend/app.py` backed by an SQLite schema in `backend/schema.sql` with demo seeding and endpoints `GET /health`, `GET /api/scripts`, `GET /api/scripts/{id}`, `PATCH /api/scripts/{id}/marks`, and `POST /api/scripts/{id}/submit`.
- Add a planning document `docs/backend-pipeline.md` describing recommended modules, data flow, API surface, and migration considerations for staging/production.
- Update `README.md` with run instructions for the static site and the demo API and add `.gitignore` to omit Python caches and the local DB file.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a095045a15883249b509fb263ada298)